### PR TITLE
refactor: remove legacy scoring interfaces

### DIFF
--- a/docs/MIGRATION_GUIDE.md
+++ b/docs/MIGRATION_GUIDE.md
@@ -158,6 +158,17 @@ python run_tests.py
 ./config/system_config.json
 ```
 
+### 6. Inference Pipeline Updates
+**BEFORE:**
+```
+Legacy `ScorerEnsemble` class and `local_search` function provided heuristic scoring and optimization.
+```
+
+**AFTER:**
+```
+These legacy components have been removed. Use the generative `GenerativeEnsemble` workflow for candidate generation and ranking.
+```
+
 ---
 
 ## 🧪 New Test System

--- a/src/inference_pipeline.py
+++ b/src/inference_pipeline.py
@@ -684,20 +684,3 @@ def save_results_to_file(detailed_results, use_i_ching, temperature):
         
     except Exception as e:
         print(f"Warning: Could not save results to file: {e}")
-
-# Legacy compatibility functions (for old scoring system)
-class ScorerEnsemble:
-    """Legacy ensemble class for backward compatibility."""
-    
-    def __init__(self, model, fe, temporal_scorer, i_ching_scorer, df_all_draws, config, use_i_ching=False):
-        print("[WARNING] Using legacy ScorerEnsemble. Consider upgrading to GenerativeEnsemble.")
-        self.config = config
-        
-    def score(self, number_set):
-        print("[WARNING] Legacy scoring called. This functionality is deprecated.")
-        return 0.5
-
-def local_search(initial_set, scorer_ensemble, max_iterations, num_neighbors):
-    """Legacy local search function for backward compatibility."""
-    print("[WARNING] Local search is deprecated. Use generative inference instead.")
-    return initial_set, 0.5


### PR DESCRIPTION
## Summary
- drop deprecated `ScorerEnsemble` and `local_search` from inference pipeline
- document removal of legacy scoring hooks in migration guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install numpy torch -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a03ec7af74832b9d84d699aad317e9