### PR TITLE
Allow configurable generation batch size

### DIFF
--- a/main.py
+++ b/main.py
@@ -202,6 +202,8 @@ def get_inference_options():
         print("Invalid input. Please enter a valid number.")
         return None
     
+    generation_batch_size = CONFIG['generation_batch_size']
+
     if method_choice == 1 or method_choice == 3:
         # AI model options
         try:
@@ -210,10 +212,22 @@ def get_inference_options():
             temperature = max(0.1, min(2.0, temperature))
         except ValueError:
             temperature = 0.8
-        
+
+        try:
+            batch_input = input(
+                f"Generation batch size (default: {CONFIG['generation_batch_size']}): "
+            )
+            generation_batch_size = (
+                int(batch_input) if batch_input else CONFIG['generation_batch_size']
+            )
+            if generation_batch_size <= 0:
+                generation_batch_size = CONFIG['generation_batch_size']
+        except ValueError:
+            generation_batch_size = CONFIG['generation_batch_size']
+
         use_iching_input = input("Use the I-Ching scorer? (y/n, default: n): ").lower()
         use_iching = use_iching_input == 'y'
-        
+
         verbose = input("Show detailed generation process? (y/n, default: y): ").lower() != 'n'
         
         print("\nGeneration Modes:")
@@ -256,7 +270,8 @@ def get_inference_options():
         'temperature': temperature,
         'use_i_ching': use_iching,
         'verbose': verbose,
-        'mode': mode_choice_detail
+        'mode': mode_choice_detail,
+        'generation_batch_size': generation_batch_size,
     }
 
 
@@ -1125,6 +1140,7 @@ def main_menu():
                     print("\n🤖 AI Model Inference Selected")
                     print(f"• Number of sets: {inference_config['num_sets']}")
                     print(f"• Temperature: {inference_config['temperature']:.2f}")
+                    print(f"• Generation batch size: {inference_config['generation_batch_size']}")
                     print(f"• I-Ching scorer: {'Yes' if inference_config['use_i_ching'] else 'No'}")
                     print(f"• Verbose output: {'Yes' if inference_config['verbose'] else 'No'}")
                     
@@ -1132,7 +1148,8 @@ def main_menu():
                         num_sets_to_generate=inference_config['num_sets'],
                         use_i_ching=inference_config['use_i_ching'],
                         temperature=inference_config['temperature'],
-                        verbose=inference_config['verbose']
+                        verbose=inference_config['verbose'],
+                        generation_batch_size=inference_config['generation_batch_size'],
                     )
                     
                 elif inference_config['method'] == 2:  # Statistical Analysis
@@ -1150,6 +1167,7 @@ def main_menu():
                     print("\n🔄 Hybrid AI + Statistical Analysis Selected")
                     print(f"• Number of sets: {inference_config['num_sets']}")
                     print(f"• AI Temperature: {inference_config['temperature']:.2f}")
+                    print(f"• Generation batch size: {inference_config['generation_batch_size']}")
                     print(f"• Statistical mode: {inference_config['mode']}")
                     
                     # Run both AI and statistical predictions
@@ -1161,7 +1179,8 @@ def main_menu():
                         num_sets_to_generate=ai_sets,
                         use_i_ching=inference_config['use_i_ching'],
                         temperature=inference_config['temperature'],
-                        verbose=False
+                        verbose=False,
+                        generation_batch_size=inference_config['generation_batch_size'],
                     )
                     
                     print(f"\n📊 Generating {stat_sets} sets using statistical analysis...")

--- a/src/config.py
+++ b/src/config.py
@@ -129,6 +129,7 @@ CONFIG = {
     "generation_temperature": 1.0,   # Increased from 0.8 (less confident)
     "num_generation_samples": 10,    # Reduced from 50
     "top_k_sampling": 5,             # Reduced from 10
+    "generation_batch_size": 1024,   # Maximum samples per generation batch
     "ensemble_selection_method": "fixed_weights",  # Changed from "meta_learned" for stability
     
     # Evaluation Parameters

--- a/src/inference_pipeline.py
+++ b/src/inference_pipeline.py
@@ -39,7 +39,13 @@ class GenerativeEnsemble:
         self.cvae_model.eval()
         self.meta_learner.eval()
         
-    def generate_candidates(self, num_candidates=50, temperature=0.8, diversity_factor=1.0):
+    def generate_candidates(
+        self,
+        num_candidates=50,
+        temperature=0.8,
+        diversity_factor=1.0,
+        generation_batch_size=None,
+    ):
         """
         Generate candidate number combinations using the CVAE.
         
@@ -47,6 +53,7 @@ class GenerativeEnsemble:
             num_candidates: Number of combinations to generate
             temperature: Sampling temperature (higher = more diverse)
             diversity_factor: Factor to encourage diversity in latent sampling
+            generation_batch_size: Maximum number of samples to generate per batch
         
         Returns:
             candidates: List of unique 6-number combinations
@@ -64,10 +71,13 @@ class GenerativeEnsemble:
                 # Generate multiple batches for diversity
                 candidates = []
                 generation_scores = []
-                
-                batch_size = min(10, num_candidates)
+
+                if generation_batch_size is None:
+                    generation_batch_size = self.config.get("generation_batch_size", 1024)
+
+                batch_size = min(generation_batch_size, num_candidates)
                 num_batches = (num_candidates + batch_size - 1) // batch_size
-                
+
                 for batch_idx in range(num_batches):
                     current_batch_size = min(batch_size, num_candidates - len(candidates))
                     
@@ -78,14 +88,11 @@ class GenerativeEnsemble:
                     else:
                         context_with_noise = context
                     
-                    # Expand context for batch
-                    batch_context = context_with_noise.expand(current_batch_size, -1)
-                    
                     # Generate combinations
                     batch_combinations, batch_log_probs = self.cvae_model.generate(
-                        batch_context,
-                        num_samples=1,
-                        temperature=temperature
+                        context_with_noise,
+                        num_samples=current_batch_size,
+                        temperature=temperature,
                     )
                     
                     # Convert to list format and filter duplicates
@@ -106,9 +113,8 @@ class GenerativeEnsemble:
                 attempts = 0
                 
                 while len(candidates) < num_candidates and attempts < max_attempts:
-                    batch_context = context.expand(1, -1)
                     combination, log_prob = self.cvae_model.generate(
-                        batch_context, num_samples=1, temperature=temperature * 1.2
+                        context, num_samples=1, temperature=temperature * 1.2
                     )
                     
                     combo = combination[0].cpu().numpy().tolist()
@@ -304,7 +310,13 @@ class GenerativeEnsemble:
             
             return ranked_candidates, final_scores_sorted, explanations_sorted
     
-    def generate_recommendations(self, num_sets, temperature=0.8, verbose=True):
+    def generate_recommendations(
+        self,
+        num_sets,
+        temperature=0.8,
+        verbose=True,
+        generation_batch_size=None,
+    ):
         """
         Main method to generate final recommendations.
         
@@ -312,6 +324,7 @@ class GenerativeEnsemble:
             num_sets: Number of final recommendations to return
             temperature: Generation temperature
             verbose: Whether to print progress
+            generation_batch_size: Maximum number of samples to generate per batch
         
         Returns:
             recommendations: Final recommended combinations
@@ -328,7 +341,8 @@ class GenerativeEnsemble:
             num_candidates = max(num_sets * 5, 50)  # Generate more candidates than needed
             candidates, generation_scores = self.generate_candidates(
                 num_candidates=num_candidates,
-                temperature=temperature
+                temperature=temperature,
+                generation_batch_size=generation_batch_size,
             )
             
             if verbose:
@@ -472,7 +486,13 @@ def find_latest_model():
     # Return the most recent model
     return existing_models[0][:4]  # Exclude timestamp from return
 
-def run_inference(num_sets_to_generate, use_i_ching=False, temperature=0.8, verbose=True):
+def run_inference(
+    num_sets_to_generate,
+    use_i_ching=False,
+    temperature=0.8,
+    verbose=True,
+    generation_batch_size=None,
+):
     """
     Main inference pipeline using the new generative approach.
     
@@ -481,6 +501,7 @@ def run_inference(num_sets_to_generate, use_i_ching=False, temperature=0.8, verb
         use_i_ching: Whether to include I-Ching scorer
         temperature: Generation temperature (higher = more diverse)
         verbose: Whether to print detailed progress
+        generation_batch_size: Maximum number of samples to generate per batch
     """
     print("\n--- Starting Generative Inference Pipeline ---")
     print("Architecture: CVAE + Meta-Learner + Ensemble Scoring")
@@ -499,8 +520,12 @@ def run_inference(num_sets_to_generate, use_i_ching=False, temperature=0.8, verb
     print(f"📁 Meta-learner: {meta_path}")
     print(f"📁 Feature engineer: {fe_path}")
     
+    if generation_batch_size is None:
+        generation_batch_size = CONFIG.get("generation_batch_size", 1024)
+
     device = torch.device(CONFIG['device'])
     print(f"Running inference on: {device}")
+    print(f"Generation batch size: {generation_batch_size}")
     
     try:
         # Load data
@@ -626,7 +651,8 @@ def run_inference(num_sets_to_generate, use_i_ching=False, temperature=0.8, verb
         recommendations, detailed_results = ensemble.generate_recommendations(
             num_sets=num_sets_to_generate,
             temperature=temperature,
-            verbose=verbose
+            verbose=verbose,
+            generation_batch_size=generation_batch_size,
         )
         
         # Display results


### PR DESCRIPTION
## Summary
- expose `generation_batch_size` (default 1024) via config and CLI
- use `generation_batch_size` when generating candidates and recommendations
- forward batch size to CVAE generation for efficient batched sampling

## Testing
- `python -m py_compile main.py src/inference_pipeline.py src/config.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68a04ee67a38832b9471c3ab72498220