### PR TITLE
feat: tune candidate generation for large inference batches

### DIFF
--- a/main.py
+++ b/main.py
@@ -201,8 +201,9 @@ def get_inference_options():
     except ValueError:
         print("Invalid input. Please enter a valid number.")
         return None
-    
+
     generation_batch_size = CONFIG['generation_batch_size']
+    candidate_multiplier = CONFIG.get('candidate_multiplier', 5)
 
     if method_choice == 1 or method_choice == 3:
         # AI model options
@@ -224,6 +225,16 @@ def get_inference_options():
                 generation_batch_size = CONFIG['generation_batch_size']
         except ValueError:
             generation_batch_size = CONFIG['generation_batch_size']
+
+        try:
+            cm_input = input(
+                f"Candidate multiplier (default: {candidate_multiplier}): "
+            )
+            candidate_multiplier = float(cm_input) if cm_input else candidate_multiplier
+            if candidate_multiplier <= 0:
+                candidate_multiplier = CONFIG.get('candidate_multiplier', 5)
+        except ValueError:
+            candidate_multiplier = CONFIG.get('candidate_multiplier', 5)
 
         use_iching_input = input("Use the I-Ching scorer? (y/n, default: n): ").lower()
         use_iching = use_iching_input == 'y'
@@ -263,7 +274,7 @@ def get_inference_options():
         temperature = 0.8
         use_iching = False
         verbose = True
-    
+
     return {
         'method': method_choice,
         'num_sets': num_sets,
@@ -272,6 +283,7 @@ def get_inference_options():
         'verbose': verbose,
         'mode': mode_choice_detail,
         'generation_batch_size': generation_batch_size,
+        'candidate_multiplier': candidate_multiplier,
     }
 
 
@@ -1150,6 +1162,7 @@ def main_menu():
                         temperature=inference_config['temperature'],
                         verbose=inference_config['verbose'],
                         generation_batch_size=inference_config['generation_batch_size'],
+                        candidate_multiplier=inference_config['candidate_multiplier'],
                     )
                     
                 elif inference_config['method'] == 2:  # Statistical Analysis
@@ -1181,6 +1194,7 @@ def main_menu():
                         temperature=inference_config['temperature'],
                         verbose=False,
                         generation_batch_size=inference_config['generation_batch_size'],
+                        candidate_multiplier=inference_config['candidate_multiplier'],
                     )
                     
                     print(f"\n📊 Generating {stat_sets} sets using statistical analysis...")

--- a/src/config.py
+++ b/src/config.py
@@ -131,6 +131,8 @@ CONFIG = {
     "top_k_sampling": 5,             # Reduced from 10
     "generation_batch_size": 1024,   # Maximum samples per generation batch
     "ensemble_selection_method": "fixed_weights",  # Changed from "meta_learned" for stability
+    "candidate_multiplier": 5,       # Multiplier for generating extra candidates
+    "large_set_threshold": 10000,    # Threshold for switching to 10% extra candidates
     
     # Evaluation Parameters
     "evaluation_neg_samples": 49,    # Reduced from 99

--- a/src/inference_pipeline.py
+++ b/src/inference_pipeline.py
@@ -331,6 +331,7 @@ class GenerativeEnsemble:
         temperature=0.8,
         verbose=True,
         generation_batch_size=None,
+        candidate_multiplier=None,
     ):
         """
         Main method to generate final recommendations.
@@ -340,6 +341,7 @@ class GenerativeEnsemble:
             temperature: Generation temperature
             verbose: Whether to print progress
             generation_batch_size: Maximum number of samples to generate per batch
+            candidate_multiplier: Multiplier for generating extra candidates
         
         Returns:
             recommendations: Final recommended combinations
@@ -352,8 +354,15 @@ class GenerativeEnsemble:
             # Step 1: Generate candidate combinations
             if verbose:
                 print("Step 1: Generating candidate combinations...")
-            
-            num_candidates = max(num_sets * 5, 50)  # Generate more candidates than needed
+
+            if candidate_multiplier is None:
+                candidate_multiplier = self.config.get("candidate_multiplier", 5)
+            threshold = self.config.get("large_set_threshold", 10000)
+
+            if num_sets > threshold:
+                num_candidates = num_sets + int(num_sets * 0.1)
+            else:
+                num_candidates = max(int(num_sets * candidate_multiplier), 50)
             candidates, generation_scores = self.generate_candidates(
                 num_candidates=num_candidates,
                 temperature=temperature,
@@ -507,6 +516,7 @@ def run_inference(
     temperature=0.8,
     verbose=True,
     generation_batch_size=None,
+    candidate_multiplier=None,
 ):
     """
     Main inference pipeline using the new generative approach.
@@ -517,6 +527,7 @@ def run_inference(
         temperature: Generation temperature (higher = more diverse)
         verbose: Whether to print detailed progress
         generation_batch_size: Maximum number of samples to generate per batch
+        candidate_multiplier: Multiplier for generating extra candidates
     """
     print("\n--- Starting Generative Inference Pipeline ---")
     print("Architecture: CVAE + Meta-Learner + Ensemble Scoring")
@@ -537,10 +548,13 @@ def run_inference(
     
     if generation_batch_size is None:
         generation_batch_size = CONFIG.get("generation_batch_size", 1024)
+    if candidate_multiplier is None:
+        candidate_multiplier = CONFIG.get("candidate_multiplier", 5)
 
     device = torch.device(CONFIG['device'])
     print(f"Running inference on: {device}")
     print(f"Generation batch size: {generation_batch_size}")
+    print(f"Candidate multiplier: {candidate_multiplier}")
     
     try:
         # Load data
@@ -662,12 +676,13 @@ def run_inference(
         print(f"\nGenerating {num_sets_to_generate} number combinations...")
         print(f"Using I-Ching scorer: {'Yes' if use_i_ching else 'No'}")
         print(f"Generation temperature: {temperature}")
-        
+        print(f"Candidate multiplier: {candidate_multiplier}")
         recommendations, detailed_results = ensemble.generate_recommendations(
             num_sets=num_sets_to_generate,
             temperature=temperature,
             verbose=verbose,
             generation_batch_size=generation_batch_size,
+            candidate_multiplier=candidate_multiplier,
         )
         
         # Display results


### PR DESCRIPTION
## Summary
- Adjust candidate generation to add only 10% extra when requesting more than 10k sets
- Expose a configurable `candidate_multiplier` for expert tuning via config and CLI
- Log multiplier usage and forward through inference pipeline

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68a0581c5764832bbc6653dc7503bcc6